### PR TITLE
Fix scroll-top handler

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -70,13 +70,15 @@
       window.scrollY > 100 ? scrollTop.classList.add('active') : scrollTop.classList.remove('active');
     }
   }
-  scrollTop.addEventListener('click', (e) => {
-    e.preventDefault();
-    window.scrollTo({
-      top: 0,
-      behavior: 'smooth'
+  if (scrollTop) {
+    scrollTop.addEventListener('click', (e) => {
+      e.preventDefault();
+      window.scrollTo({
+        top: 0,
+        behavior: 'smooth'
+      });
     });
-  });
+  }
 
   window.addEventListener('load', toggleScrollTop);
   document.addEventListener('scroll', toggleScrollTop);


### PR DESCRIPTION
## Summary
- guard event listener in main.js when scroll button is missing

## Testing
- `tidy -e index.html | head`

------
https://chatgpt.com/codex/tasks/task_e_6860645a3aa88333b632cfd6ce70886b